### PR TITLE
Eliminate MacPorts dependency on Apple platforms [#3]

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -43,12 +43,12 @@ ifeq ($(shell uname), Darwin)
 		HOMEBREW_BASE = /opt/homebrew
 	endif
 
-	CFLAGS_EXTRA = -D__MACOS__ -D__MACOS_SDKROOT__=$(SDKROOT) -D__HOMEBREW_BASE__=$(HOMEBREW_BASE) -I/opt/local/include -I$(HOMEBREW_BASE)/opt/llvm@15/include -mmacosx-version-min=12.0
-	LFLAGS_EXTRA = -L/opt/local/lib -L$(HOMEBREW_BASE)/opt/gperftools/lib -L$(HOMEBREW_BASE)/opt/llvm@15/lib -L$(HOMEBREW_BASE)/Cellar/ncurses/6.3/lib -L/Library/Developer/CommandLineTools/SDKs/MacOSX.sdk/usr/lib
+	CFLAGS_EXTRA = -D__MACOS_SDKROOT__=$(SDKROOT) -D__HOMEBREW_BASE__=$(HOMEBREW_BASE) -I$(HOMEBREW_BASE)/opt/llvm@15/include -mmacosx-version-min=12.0
+	LFLAGS_EXTRA = -L$(HOMEBREW_BASE)/opt/gperftools/lib -L$(HOMEBREW_BASE)/opt/llvm@15/lib -L$(HOMEBREW_BASE)/Cellar/ncurses/6.3/lib -L/Library/Developer/CommandLineTools/SDKs/MacOSX.sdk/usr/lib
 	CC = $(HOMEBREW_BASE)/opt/llvm@15/bin/clang++
 else
 	CFLAGS_EXTRA = -I/usr/include/llvm-c-14 -I/usr/include/llvm-14
-	LFLAGS_EXTRA = -L/usr/lib/llvm-14/lib
+	LFLAGS_EXTRA = -L/usr/lib/llvm-14/lib -lcryptopp
 	CC = clang++
 endif
 
@@ -61,7 +61,7 @@ endif
 # release
 CFLAGS = -I./src -I./gen -g -ggdb -g3 -O3 -std=c++17 -fno-omit-frame-pointer $(CFLAGS_EXTRA)
 LFLAGS = $(LFLAGS_EXTRA) \
-	-lLLVMSymbolize -lLLVMDemangle -lLLVMSupport -lcryptopp -lncurses $(LFLAGS_TCMALLOC)
+	-lLLVMSymbolize -lLLVMDemangle -lLLVMSupport -lncurses $(LFLAGS_TCMALLOC)
 
 HPP_SRC = $(wildcard src/*.hpp)
 

--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ For Ubuntu 22.04:
 make -j8
 sudo make install
 ```
-For macOS 12.5 (requires Homebrew and MacPorts):
+For macOS 12.5 (requires Homebrew):
 ```
 ./deps_macos.sh
 make -j8

--- a/deps_macos.sh
+++ b/deps_macos.sh
@@ -3,4 +3,3 @@ brew update
 brew install llvm@15
 brew install gperftools
 brew install ncurses
-sudo port install libcryptopp @8.7.0

--- a/examples/calc/Makefile
+++ b/examples/calc/Makefile
@@ -20,18 +20,18 @@ ifeq ($(shell uname), Darwin)
 		HOMEBREW_BASE = /opt/homebrew
 	endif
 
-	CFLAGS_EXTRA = -D__MACOS__ -D__MACOS_SDKROOT__=$(SDKROOT) -D__HOMEBREW_BASE__=$(HOMEBREW_BASE) -I/opt/local/include -I$(HOMEBREW_BASE)/opt/llvm@15/include -mmacosx-version-min=12.0
-	LFLAGS_EXTRA = -L/opt/local/lib -L$(HOMEBREW_BASE)/opt/gperftools/lib -L$(HOMEBREW_BASE)/opt/llvm@15/lib -L$(HOMEBREW_BASE)/Cellar/ncurses/6.3/lib -L/Library/Developer/CommandLineTools/SDKs/MacOSX.sdk/usr/lib
+	CFLAGS_EXTRA = -D__MACOS_SDKROOT__=$(SDKROOT) -D__HOMEBREW_BASE__=$(HOMEBREW_BASE) -I$(HOMEBREW_BASE)/opt/llvm@15/include -mmacosx-version-min=12.0
+	LFLAGS_EXTRA = -L$(HOMEBREW_BASE)/opt/gperftools/lib -L$(HOMEBREW_BASE)/opt/llvm@15/lib -L$(HOMEBREW_BASE)/Cellar/ncurses/6.3/lib -L/Library/Developer/CommandLineTools/SDKs/MacOSX.sdk/usr/lib
 	CC = $(HOMEBREW_BASE)/opt/llvm@15/bin/clang++
 else
 	CFLAGS_EXTRA = -I/usr/include/llvm-c-14 -I/usr/include/llvm-14
-	LFLAGS_EXTRA = -L/usr/lib/llvm-14/lib
+	LFLAGS_EXTRA = -L/usr/lib/llvm-14/lib -lcryptopp
 	CC = clang++
 endif
 
 CFLAGS = -I./gen -I./include -g -ggdb -g3 -std=c++17 -fno-omit-frame-pointer $(CFLAGS_EXTRA)
 LFLAGS = $(LFLAGS_EXTRA) \
-	-lLLVMSymbolize -lLLVMDemangle -lLLVMSupport -lcryptopp -lncurses $(LFLAGS_TCMALLOC)
+	-lLLVMSymbolize -lLLVMDemangle -lLLVMSupport -lncurses $(LFLAGS_TCMALLOC)
 
 gen/calc__gen.cpp: calc.lang Makefile
 	langcc calc.lang gen

--- a/src/langcc.cpp
+++ b/src/langcc.cpp
@@ -162,22 +162,22 @@ LangCompileResult_T compile_lang_full(string src_path, string dst_path, bool run
     if (run_tests) {
         makedirs("build/gen_test_bin");
 
-#ifdef __MACOS__
+#ifdef __APPLE__
         string sdkroot = STRINGIFY(__MACOS_SDKROOT__);
         setenv("SDKROOT", sdkroot.c_str(), 1);
         string hb = STRINGIFY(__HOMEBREW_BASE__);
 #endif
 
         Vec<string> cmds;
-#ifdef __MACOS__
+#ifdef __APPLE__
         cmds.push(fmt_str("{}/opt/llvm@15/bin/clang++", hb));
 #else
         cmds.push("clang++");
 #endif
 
-#ifdef __MACOS__
+#ifdef __APPLE__
         cmds.push("-D");
-        cmds.push("__MACOS__");
+        cmds.push("__APPLE__");
         cmds.push("-D");
         cmds.push(fmt_str("__MACOS_SDKROOT__={}", sdkroot));
         cmds.push("-D");
@@ -193,10 +193,8 @@ LangCompileResult_T compile_lang_full(string src_path, string dst_path, bool run
         cmds.push("-g3");
         cmds.push("-std=c++17");
         cmds.push("-fno-omit-frame-pointer");
-#ifdef __MACOS__
+#ifdef __APPLE__
         cmds.push("-mmacosx-version-min=12.0");
-        cmds.push("-I");
-        cmds.push("/opt/local/include");
         cmds.push("-I");
         cmds.push(fmt_str("{}/opt/llvm@15/include", hb));
 #else
@@ -211,9 +209,7 @@ LangCompileResult_T compile_lang_full(string src_path, string dst_path, bool run
         cmds.push("./src");
         cmds.push(res->as_Ok()->cpp_path_);
         cmds.push(res->as_Ok()->cpp_test_path_);
-#ifdef __MACOS__
-        cmds.push("-L");
-        cmds.push("/opt/local/lib");
+#ifdef __APPLE__
         cmds.push("-L");
         cmds.push(fmt_str("{}/opt/gperftools/lib", hb));
         cmds.push("-L");
@@ -225,11 +221,11 @@ LangCompileResult_T compile_lang_full(string src_path, string dst_path, bool run
 #else
         cmds.push("-L");
         cmds.push("/usr/lib/llvm-14");
+        cmds.push("-lcryptopp");
 #endif
         cmds.push("-lLLVMSymbolize");
         cmds.push("-lLLVMDemangle");
         cmds.push("-lLLVMSupport");
-        cmds.push("-lcryptopp");
         cmds.push("-lncurses");
 
         string cmd;

--- a/src/langcc_util.hpp
+++ b/src/langcc_util.hpp
@@ -27,8 +27,8 @@
 #include <unordered_set>
 #include <vector>
 
-#ifdef __MACOS__
-#include <cryptopp/sha.h>
+#ifdef __APPLE__
+#include <CommonCrypto/CommonDigest.h>
 #include <signal.h>
 #else
 #include <crypto++/sha.h>
@@ -2069,9 +2069,13 @@ struct hash_obj {
 
 inline HashVal hash_data(const u8* data, Int len) {
     HashVal ret;
+#ifdef __APPLE__
+    CC_SHA256(data, len, &ret.v_[0]);
+#else
     CryptoPP::SHA256 hash;
     hash.Update(data, len);
     hash.Final(&ret.v_[0]);
+#endif
     return ret;
 }
 


### PR DESCRIPTION
On Apple platforms:
- Use standard `__APPLE__` macro for C++ platform detection
- Call SHA256 fn from system CommonCrypto library, not libcryptopp
- Don't link against libcryptopp
- Don't add MacPorts include or library dirs to search paths

Tested on macOS 12.6. Have not tried non-Apple OSs yet.

Everything works fine up until after the `xfail_lexer_conflict` test … then my system (M1 MacBook Pro, 16GB RAM) bogs down and nothing happens for 10 minutes or more. The test seems to be creating clang processes like crazy — when I killed it there were about 300 of them. I have no idea whether this is related to my changes or not; I opted not to install MacPorts so I can’t run the unmodified code. Maybe this test has only been run on systems with a lot more RAM?

Fixes #3