### PR TITLE
Replaced __MACOS__ with __APPLE__ (which is built in)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -59,7 +59,7 @@ ifeq ($(shell uname), Darwin)
 		HOMEBREW_BASE = /opt/homebrew
 	endif
 
-	CFLAGS_EXTRA = -D__CC__=$(CC) -D__MACOS__ -D__MACOS_SDKROOT__=$(SDKROOT) -mmacosx-version-min=12.0
+	CFLAGS_EXTRA = -D__CC__=$(CC) -D__MACOS_SDKROOT__=$(SDKROOT) -mmacosx-version-min=12.0
 	LFLAGS_EXTRA = -L/opt/local/lib -L$(HOMEBREW_BASE)/opt/gperftools/lib -L/Library/Developer/CommandLineTools/SDKs/MacOSX.sdk/usr/lib -ldl
 	CC = clang++
 	DSYMUTIL_MAYBE = dsymutil

--- a/examples/calc/Makefile
+++ b/examples/calc/Makefile
@@ -22,7 +22,7 @@ ifeq ($(shell uname), Darwin)
 		HOMEBREW_BASE = /opt/homebrew
 	endif
 
-	CFLAGS_EXTRA = -isystem /usr/local/include -D__MACOS__ -D__MACOS_SDKROOT__=$(SDKROOT) -D__HOMEBREW_BASE__=$(HOMEBREW_BASE) -mmacosx-version-min=12.0
+	CFLAGS_EXTRA = -isystem /usr/local/include -D__MACOS_SDKROOT__=$(SDKROOT) -D__HOMEBREW_BASE__=$(HOMEBREW_BASE) -mmacosx-version-min=12.0
 	LFLAGS_EXTRA = -L/opt/local/lib -L$(HOMEBREW_BASE)/opt/gperftools/lib -L/Library/Developer/CommandLineTools/SDKs/MacOSX.sdk/usr/lib -ldl
 	CC = clang++
 	DSYMUTIL_MAYBE = dsymutil

--- a/src/langcc.cpp
+++ b/src/langcc.cpp
@@ -166,7 +166,7 @@ LangCompileResult_T compile_lang_full(
     if (run_tests == RunTests::Y) {
         makedirs("build/gen_test_bin");
 
-#ifdef __MACOS__
+#ifdef __APPLE__
         string sdkroot = STRINGIFY(__MACOS_SDKROOT__);
         setenv("SDKROOT", sdkroot.c_str(), 1);
 #endif
@@ -175,13 +175,11 @@ LangCompileResult_T compile_lang_full(
         string cc = STRINGIFY(__CC__);
         cmds.push(cc);
 
-#ifndef __MACOS__
+#ifndef __APPLE__
         cmds.push("-Wno-attributes");
 #endif
 
-#ifdef __MACOS__
-        cmds.push("-D");
-        cmds.push("__MACOS__");
+#ifdef __APPLE__
         cmds.push("-D");
         cmds.push(fmt_str("__MACOS_SDKROOT__={}", sdkroot));
         cmds.push("-isystem");
@@ -197,7 +195,7 @@ LangCompileResult_T compile_lang_full(
         cmds.push("-g3");
         cmds.push("-std=c++17");
         cmds.push("-fno-omit-frame-pointer");
-#ifdef __MACOS__
+#ifdef __APPLE__
         cmds.push("-mmacosx-version-min=12.0");
 #endif
         cmds.push("-I");
@@ -208,7 +206,7 @@ LangCompileResult_T compile_lang_full(
             cmds.push(res->as_Ok()->cpp_path_);
         }
         cmds.push(res->as_Ok()->cpp_test_path_);
-#ifndef __MACOS__
+#ifndef __APPLE__
         cmds.push("-lunwind");
 #endif
         cmds.push("-ldl");

--- a/src/langcc_util.hpp
+++ b/src/langcc_util.hpp
@@ -29,7 +29,7 @@
 #include <unordered_set>
 #include <vector>
 
-#ifdef __MACOS__
+#ifdef __APPLE__
 #include <signal.h>
 #endif
 
@@ -4033,7 +4033,7 @@ inline void dump_stack() {
         Dl_info info;
         dladdr(reinterpret_cast<void*>(ip), &info);
         auto offs = ip - reinterpret_cast<u64>(info.dli_fbase);
-#ifdef __MACOS__
+#ifdef __APPLE__
         offs += 0x100000000UL;
         offs -= 1;
 #endif


### PR DESCRIPTION
Using a custom env var to signal compiling on macOS makes it slightly harder to incorporate into other build systems, so this uses the built in equivalent instead.